### PR TITLE
Asset manager rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
     src/ufo/actor.cpp
     src/ufo/animation.cpp
     src/ufo/assets.cpp
+    src/ufo/asset_manager.cpp
     src/ufo/button.cpp
     src/ufo/collision_body.cpp
     src/ufo/dynamic_solid.cpp

--- a/src/ufo/animation.cpp
+++ b/src/ufo/animation.cpp
@@ -4,6 +4,7 @@
 #include "game.h"
 #include "../../external/olcPixelGameEngine.h"
 #include <string>
+#include "asset_manager.h"
 
 Animation::Animation(Game* _game, olc::vf2d _frame_size, float _delta_frames, std::string _sprite_sheet):
     game{_game},
@@ -54,7 +55,7 @@ Animation::UpdateStateLogic(){
 
 void
 Animation::Draw(Camera* _camera, olc::vf2d _position, olc::vf2d _scale){
-    _camera->DrawRotatedPartialDecal(_position, game->asset_manager.GetDecal(sprite_sheet),{0.0f,0.0f}, GetFrame(current_anim[(int)frame_count%current_anim.size()]).position, frame_size, _scale);
+    _camera->DrawRotatedPartialDecal(_position, AssetManager::GetSelf().GetDecal(sprite_sheet),{0.0f,0.0f}, GetFrame(current_anim[(int)frame_count%current_anim.size()]).position, frame_size, _scale);
 }
 
 Rect
@@ -66,6 +67,6 @@ Animation::GetRectangle(int _x, int _y){
 Rect
 Animation::GetFrame(int _frame){
     return GetRectangle(
-        (int)_frame % (game->asset_manager.GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x), //1 can only give me x = 0
-        (int)_frame / (game->asset_manager.GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x)); //1 can only give y = 1
+        (int)_frame % (AssetManager::GetSelf().GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x), //1 can only give me x = 0
+        (int)_frame / (AssetManager::GetSelf().GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x)); //1 can only give y = 1
 }

--- a/src/ufo/animation.cpp
+++ b/src/ufo/animation.cpp
@@ -55,7 +55,7 @@ Animation::UpdateStateLogic(){
 
 void
 Animation::Draw(Camera* _camera, olc::vf2d _position, olc::vf2d _scale){
-    _camera->DrawRotatedPartialDecal(_position, AssetManager::GetSelf().GetDecal(sprite_sheet),{0.0f,0.0f}, GetFrame(current_anim[(int)frame_count%current_anim.size()]).position, frame_size, _scale);
+    _camera->DrawRotatedPartialDecal(_position, AssetManager::Get().GetDecal(sprite_sheet),{0.0f,0.0f}, GetFrame(current_anim[(int)frame_count%current_anim.size()]).position, frame_size, _scale);
 }
 
 Rect
@@ -67,6 +67,6 @@ Animation::GetRectangle(int _x, int _y){
 Rect
 Animation::GetFrame(int _frame){
     return GetRectangle(
-        (int)_frame % (AssetManager::GetSelf().GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x), //1 can only give me x = 0
-        (int)_frame / (AssetManager::GetSelf().GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x)); //1 can only give y = 1
+        (int)_frame % (AssetManager::Get().GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x), //1 can only give me x = 0
+        (int)_frame / (AssetManager::Get().GetDecal(sprite_sheet)->sprite->Size().x/(int)frame_size.x)); //1 can only give y = 1
 }

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -1,0 +1,64 @@
+#include "../../olcPixelGameEngine.h"
+#include <memory>
+#include "asset_manager.h"
+#include "console.h"
+
+void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {
+    olc::Sprite* spr = new olc::Sprite();
+
+    switch (spr->LoadFromFile(_path)){
+        case olc::rcode::NO_FILE:
+            Console::Out("Error: The file does not exist at path", _path);
+            break;
+        case olc::rcode::FAIL:
+            Console::Out("Error: Failed to load the file at path", _path);
+            break;
+        default:
+            break;
+    }
+
+    sprites[_name] = std::make_unique<olc::Sprite>(spr);
+}
+
+olc::Sprite*
+AssetManager::GetSprite(std::string _name) {
+    if(sprites.count(_name)) Console::Out("Error: No entry with given key.");
+    return sprites.at(_name).get();
+}
+
+void
+AssetManager::RemoveSprite(){
+    if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
+}
+
+void AssetManager::LoadDecal(const std::string& _path, const std::string& _name) {
+    olc::Sprite* spr = new olc::Sprite();
+
+    switch (spr->LoadFromFile(_path)){
+        case olc::rcode::NO_FILE:
+            Console::Out("Error: The file does not exist at path", _path);
+            break;
+        case olc::rcode::FAIL:
+            Console::Out("Error: Failed to load the file at path", _path);
+            break;
+        default:
+            break;
+    }
+
+    olc::Decal* dec = new olc::Decal(spr);
+
+    sprites[_name] = std::make_unique<olc::Sprite>(spr);
+    decals[_name] = std::make_unique<olc::Decal>(dec);
+}
+
+olc::Decal*
+AssetManager::GetDecal(std::string _name) {
+    if(decals.count(_name)) Console::Out("Error: No entry with given key.");
+    return decals.at(_name).get();
+}
+
+void
+AssetManager::RemoveDecal(){
+    if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
+    if(!decals.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
+}

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -2,9 +2,11 @@
 #include <memory>
 #include "asset_manager.h"
 #include "console.h"
+#include <map>
 
 std::map<std::string, std::unique_ptr<olc::Sprite>>& AssetManager::GetSprites(){
-    return sprites;
+    static AssetManager self;
+    return self.sprites;
 }
 
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -32,11 +32,6 @@ AssetManager::GetSprite(std::string _name) {
     return sprites.at(_name).get();
 }
 
-void
-AssetManager::RemoveSprite(std::string _name){
-    if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
-}
-
 std::map<std::string, std::unique_ptr<olc::Decal>>& AssetManager::GetDecals(){
     return decals;
 }
@@ -71,7 +66,7 @@ AssetManager::GetDecal(std::string _name) {
 }
 
 void
-AssetManager::RemoveDecal(std::string _name){
+AssetManager::RemoveAsset(std::string _name){
     if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
     if(!decals.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
 }

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -36,6 +36,10 @@ AssetManager::RemoveSprite(std::string _name){
     if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
 }
 
+std::map<std::string, std::unique_ptr<olc::Decal>>& AssetManager::GetDecals(){
+    return decals;
+}
+
 void AssetManager::LoadDecal(const std::string& _path, const std::string& _name) {
     olc::Sprite* spr = new olc::Sprite(_path);
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -60,7 +60,7 @@ void AssetManager::LoadDecal(const std::string& _path, const std::string& _name)
     if(!sprites.count(_name)) sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
     else Console::Out("Sprite with key: " + _name + " already exists");
 
-    if(!sprites.count(_name)) decals[_name] = std::unique_ptr<olc::Decal>(dec);
+    if(!decals.count(_name)) decals[_name] = std::unique_ptr<olc::Decal>(dec);
     else Console::Out("Decal with key: " + _name + " already exists");
 }
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -28,7 +28,7 @@ void AssetManager::LoadSprite(const std::string& _path, const std::string& _name
 
 olc::Sprite*
 AssetManager::GetSprite(std::string _name) {
-    if(!sprites.count(_name)) Console::Out("Error: No entry with given key.");
+    if(!sprites.count(_name)) Console::Out("Sprite with key: " + _name + " does not exist");
     return sprites.at(_name).get();
 }
 
@@ -61,7 +61,7 @@ void AssetManager::LoadDecal(const std::string& _path, const std::string& _name)
 
 olc::Decal*
 AssetManager::GetDecal(std::string _name) {
-    if(!decals.count(_name)) Console::Out("Error: No entry with given key.");
+    if(!decals.count(_name)) Console::Out("Decal with key: " + _name + " does not exist");
     return decals.at(_name).get();
 }
 
@@ -70,9 +70,9 @@ AssetManager::RemoveAsset(std::string _name){
     bool sprite_was_deleted = sprites.erase(_name);
     bool decal_was_deleted = decals.erase(_name);
 
-    if(!sprite_was_deleted) Console::Out("Error: Sprite with given key does not exist.");
+    if(!sprite_was_deleted) Console::Out("Sprite with key: " + _name + " does not exist");
     if(!decal_was_deleted){
-        if(!sprite_was_deleted) Console::Out("Error: Decal with given key does not exist.");
-        else Console::Out("Only sprite was loaded");
+        if(!sprite_was_deleted) Console::Out("Decal with key: " + _name + " does not exist");
+        else Console::Out("Only sprite was loaded for: " + _name);
     }
 }

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -1,4 +1,4 @@
-#include "../../olcPixelGameEngine.h"
+#include "../../external/olcPixelGameEngine.h"
 #include <memory>
 #include "asset_manager.h"
 #include "console.h"

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -4,7 +4,7 @@
 #include "console.h"
 
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {
-    olc::Sprite* spr = new olc::Sprite();
+    olc::Sprite* spr = new olc::Sprite(_path);
 
     switch (spr->LoadFromFile(_path)){
         case olc::rcode::NO_FILE:
@@ -32,7 +32,7 @@ AssetManager::RemoveSprite(std::string _name){
 }
 
 void AssetManager::LoadDecal(const std::string& _path, const std::string& _name) {
-    olc::Sprite* spr = new olc::Sprite();
+    olc::Sprite* spr = new olc::Sprite(_path);
 
     switch (spr->LoadFromFile(_path)){
         case olc::rcode::NO_FILE:

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -4,9 +4,8 @@
 #include "console.h"
 #include <map>
 
-std::map<std::string, std::unique_ptr<olc::Sprite>> AssetManager::GetSprites(){
-    std::map<std::string, std::unique_ptr<olc::Sprite>> m(sprites);
-    return m;
+std::map<std::string, std::unique_ptr<olc::Sprite>>& AssetManager::GetSprites(){
+    return sprites;
 }
 
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -4,11 +4,6 @@
 #include "console.h"
 #include <map>
 
-std::map<std::string, std::unique_ptr<olc::Sprite>>& AssetManager::GetSprites(){
-    static AssetManager self;
-    return self.sprites;
-}
-
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {
     olc::Sprite* spr = new olc::Sprite(_path);
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -5,7 +5,8 @@
 #include <map>
 
 std::map<std::string, std::unique_ptr<olc::Sprite>> AssetManager::GetSprites(){
-    return sprites;
+    std::map<std::string, std::unique_ptr<olc::Sprite>> m = sprites;
+    return m;
 }
 
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -22,7 +22,7 @@ void AssetManager::LoadSprite(const std::string& _path, const std::string& _name
 
 olc::Sprite*
 AssetManager::GetSprite(std::string _name) {
-    if(sprites.count(_name)) Console::Out("Error: No entry with given key.");
+    if(!sprites.count(_name)) Console::Out("Error: No entry with given key.");
     return sprites.at(_name).get();
 }
 
@@ -53,7 +53,7 @@ void AssetManager::LoadDecal(const std::string& _path, const std::string& _name)
 
 olc::Decal*
 AssetManager::GetDecal(std::string _name) {
-    if(decals.count(_name)) Console::Out("Error: No entry with given key.");
+    if(!decals.count(_name)) Console::Out("Error: No entry with given key.");
     return decals.at(_name).get();
 }
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -4,8 +4,7 @@
 #include "console.h"
 
 std::map<std::string, std::unique_ptr<olc::Sprite>>& AssetManager::GetSprites(){
-    static AssetManager self;
-    return self.sprites;
+    return sprites;
 }
 
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -4,6 +4,10 @@
 #include "console.h"
 #include <map>
 
+std::map<std::string, std::unique_ptr<olc::Sprite>> AssetManager::GetSprites(){
+    return sprites;
+}
+
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {
     olc::Sprite* spr = new olc::Sprite(_path);
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -27,7 +27,7 @@ AssetManager::GetSprite(std::string _name) {
 }
 
 void
-AssetManager::RemoveSprite(){
+AssetManager::RemoveSprite(std::string _name){
     if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
 }
 
@@ -58,7 +58,7 @@ AssetManager::GetDecal(std::string _name) {
 }
 
 void
-AssetManager::RemoveDecal(){
+AssetManager::RemoveDecal(std::string _name){
     if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
     if(!decals.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
 }

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -22,7 +22,8 @@ void AssetManager::LoadSprite(const std::string& _path, const std::string& _name
             break;
     }
 
-    sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
+    if(!sprites.count(_name)) sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
+    else Console::Out("Sprite with key: " + _name + " already exists");
 }
 
 olc::Sprite*
@@ -56,8 +57,11 @@ void AssetManager::LoadDecal(const std::string& _path, const std::string& _name)
 
     olc::Decal* dec = new olc::Decal(spr);
 
-    sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
-    decals[_name] = std::unique_ptr<olc::Decal>(dec);
+    if(!sprites.count(_name)) sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
+    else Console::Out("Sprite with key: " + _name + " already exists");
+
+    if(!sprites.count(_name)) decals[_name] = std::unique_ptr<olc::Decal>(dec);
+    else Console::Out("Decal with key: " + _name + " already exists");
 }
 
 olc::Decal*

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -3,6 +3,11 @@
 #include "asset_manager.h"
 #include "console.h"
 
+std::map<std::string, std::unique_ptr<olc::Sprite>>& AssetManager::GetSprites(){
+    static AssetManager self;
+    return self.sprites;
+}
+
 void AssetManager::LoadSprite(const std::string& _path, const std::string& _name) {
     olc::Sprite* spr = new olc::Sprite(_path);
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -67,6 +67,12 @@ AssetManager::GetDecal(std::string _name) {
 
 void
 AssetManager::RemoveAsset(std::string _name){
-    if(!sprites.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
-    if(!decals.erase(_name)) Console::Out("Error: Sprite with given key does not exist.");
+    bool sprite_was_deleted = sprites.erase(_name);
+    bool decal_was_deleted = decals.erase(_name);
+
+    if(!sprite_was_deleted) Console::Out("Error: Sprite with given key does not exist.");
+    if(!decal_was_deleted){
+        if(!sprite_was_deleted) Console::Out("Error: Decal with given key does not exist.");
+        else Console::Out("Only sprite was loaded");
+    }
 }

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -5,7 +5,7 @@
 #include <map>
 
 std::map<std::string, std::unique_ptr<olc::Sprite>> AssetManager::GetSprites(){
-    std::map<std::string, std::unique_ptr<olc::Sprite>> m = sprites;
+    std::map<std::string, std::unique_ptr<olc::Sprite>> m(sprites);
     return m;
 }
 

--- a/src/ufo/asset_manager.cpp
+++ b/src/ufo/asset_manager.cpp
@@ -17,7 +17,7 @@ void AssetManager::LoadSprite(const std::string& _path, const std::string& _name
             break;
     }
 
-    sprites[_name] = std::make_unique<olc::Sprite>(spr);
+    sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
 }
 
 olc::Sprite*
@@ -47,8 +47,8 @@ void AssetManager::LoadDecal(const std::string& _path, const std::string& _name)
 
     olc::Decal* dec = new olc::Decal(spr);
 
-    sprites[_name] = std::make_unique<olc::Sprite>(spr);
-    decals[_name] = std::make_unique<olc::Decal>(dec);
+    sprites[_name] = std::unique_ptr<olc::Sprite>(spr);
+    decals[_name] = std::unique_ptr<olc::Decal>(dec);
 }
 
 olc::Decal*

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,9 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    std::map<std::string, std::unique_ptr<olc::Sprite>> GetSprites(){
-        return sprites;
-    }
+    std::map<std::string, std::unique_ptr<olc::Sprite>> GetSprites();
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -6,7 +6,7 @@
 #include <memory>
 
 class AssetManager{
-
+public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
@@ -17,7 +17,7 @@ class AssetManager{
     olc::Decal* GetDecal(std::string _name);
     void RemoveDecal(std::string _name);
 
-    AssetManager& GetSelf(){static AssetManager self; return self;} //this practically makes AssetManager global.
+    static AssetManager& GetSelf(){static AssetManager self; return self;} //this practically makes AssetManager global.
 
 };
 

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -15,6 +15,7 @@ public:
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);
+    std::map<std::string, std::unique_ptr<olc::Decal>>& GetDecals();
     void LoadDecal(const std::string& _path, const std::string& _name); //wouldn't this load both a sprite and a decal? And should the load functions return something?
     olc::Decal* GetDecal(std::string _name);
     void RemoveDecal(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -1,0 +1,22 @@
+#ifndef ASSET_MANAGER_H
+#define ASSET_MANAGER_H
+#include "../../external/olcPixelGameEngine.h"
+#include <string>
+#include <map>
+#include <memory>
+
+class AssetManager{
+
+    std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
+    std::map<std::string,std::unique_ptr<olc::Decal>> decals;
+
+    void LoadSprite(const std::string& _path, const std::string& _name);
+    olc::Sprite* GetSprite(std::string _name);
+    void LoadDecal(const std::string& _path, const std::string& _name); //wouldn't this load both a sprite and a decal? And should the load functions return something?
+    olc::Decal* GetDecal(std::string _name);
+
+    AssetManager& GetSelf(){static AssetManager self; return self;} //this practically makes AssetManager global.
+
+};
+
+#endif

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -12,8 +12,10 @@ class AssetManager{
 
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
+    void RemoveSprite(std::string _name);
     void LoadDecal(const std::string& _path, const std::string& _name); //wouldn't this load both a sprite and a decal? And should the load functions return something?
     olc::Decal* GetDecal(std::string _name);
+    void RemoveDecal(std::string _name);
 
     AssetManager& GetSelf(){static AssetManager self; return self;} //this practically makes AssetManager global.
 

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,7 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    std::map<std::string, std::unique_ptr<olc::Sprite>> GetSprites();
+    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,7 +11,10 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
+    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
+        static AssetManager self;
+        return self.sprites;
+    }
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,7 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
+    static std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
         static AssetManager self;
         return self.sprites;
     }

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,7 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
+    std::map<std::string, std::unique_ptr<olc::Sprite>> GetSprites(){
         return sprites;
     }
     void LoadSprite(const std::string& _path, const std::string& _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,7 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    static std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
+    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -14,11 +14,10 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
-    void RemoveSprite(std::string _name);
     std::map<std::string, std::unique_ptr<olc::Decal>>& GetDecals();
     void LoadDecal(const std::string& _path, const std::string& _name); //wouldn't this load both a sprite and a decal? And should the load functions return something?
     olc::Decal* GetDecal(std::string _name);
-    void RemoveDecal(std::string _name);
+    void RemoveAsset(std::string _name);
 
     static AssetManager& Get(){static AssetManager self; return self;} //this practically makes AssetManager global.
 

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,8 +11,8 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    static std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
-        return GetSelf().sprites;
+    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
+        return sprites;
     }
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -20,7 +20,7 @@ public:
     olc::Decal* GetDecal(std::string _name);
     void RemoveDecal(std::string _name);
 
-    static AssetManager& GetSelf(){static AssetManager self; return self;} //this practically makes AssetManager global.
+    static AssetManager& Get(){static AssetManager self; return self;} //this practically makes AssetManager global.
 
 };
 

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -12,8 +12,7 @@ public:
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
     static std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites(){
-        static AssetManager self;
-        return self.sprites;
+        return GetSelf().sprites;
     }
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,7 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
-    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
+    static std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -7,6 +7,7 @@
 
 class AssetManager{
 public:
+    AssetManager() = default;
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 

--- a/src/ufo/asset_manager.h
+++ b/src/ufo/asset_manager.h
@@ -11,6 +11,7 @@ public:
     std::map<std::string, std::unique_ptr<olc::Sprite>> sprites;
     std::map<std::string,std::unique_ptr<olc::Decal>> decals;
 
+    std::map<std::string, std::unique_ptr<olc::Sprite>>& GetSprites();
     void LoadSprite(const std::string& _path, const std::string& _name);
     olc::Sprite* GetSprite(std::string _name);
     void RemoveSprite(std::string _name);


### PR DESCRIPTION
Basically, the class AssetManager is statically instantiated via the Get() method. It features the following methods:
GetSprites() gets std::map with key : Sprite pairs.
GetDecals() gets std::map with key : Decal pairs.
GetSprite(_name) gets sprite by name
GetDecal(_name) gets decal by name
LoadSprite(_path, _name) loads sprite from path, under name. This does not load a Decal however.
LoadDecal(_path, _name) loads decal from path, under name. This loads a Sprite with same key name implicitly.
RemoveAsset(_name) Tries to remove sprite and/or decal under said key. If you did not load any decal, but did load a sprite, it is assumed that you only tried to load a Sprite and console will say "Only Sprite was loaded: name".

This class could be a problem if we somehow want another assetmanager, as this assetmanager is  a singleton.